### PR TITLE
MFA signalling

### DIFF
--- a/shibboleth-integration-idpv3/README.md
+++ b/shibboleth-integration-idpv3/README.md
@@ -12,6 +12,13 @@ Tuakiri is running this code in production, with a customized version of the vir
 To use the full functionality of this code, one would need to use the version of the virtualhome application extended by REANNZ for Tuakiri.  Specifically:
 * support for `forceAuthn="true"` requires the virtualhome application to return the timestamp of the authentication on the API exposed to this module.  This was introduced as an extension in the Tuakiri version.
 * the module also tries to pass the service name to the login page - but this get only accepted by the Tuakiri version.
+* support for signalling whether MFA was used through the set of principals returned.  This mode gets activated by setting the `mfaPrincipalName` initialisation parameter for the `VhrRemoteUserAuthServlet`.
+  *  In this mode, the servlet iterates over the principals (authentication contexts) configured as supported by the authentication flow, and adds them to the returned Subject according to the following rules:
+    * the principal matching the mfaPrincipalName parameter is only added when MFA is used by the user account.
+    * all other principals are assumed to represent Single Authentication Factor (SFA) flows and are added regardless whether MFA was used in the session.
+  * Note that this mode requires version of the VHO app extended to include the MFA status in the authentication response.
+  * Note also that it requires the IdP to have the RemoteUser authentication flow configured with correct set of supportedPrincipals, extended to include the principal referred to by `mfaPrincipalName` (recommended to use `https://refeds.org/profile/mfa`).
+  * It also requires the `RemoteUser` authentication flow configured not to automatically add all support principals (which would conflict with the approach of adding the MFA principal only when MFA is actually used).  This is achieved by setting the `addDefaultPrincipals` bean (or property) to False.
 
 This module MAY work with the AAF version of virtualhome (without the two features above), but AAF provides absolutely no support for this module.
 

--- a/shibboleth-integration-idpv3/build.gradle
+++ b/shibboleth-integration-idpv3/build.gradle
@@ -34,11 +34,13 @@ dependencies {
 
   [
     'net.shibboleth.idp:idp-authn-api:4.2.1',
-    'net.shibboleth.idp:idp-ui:4.2.1',
     'net.shibboleth.idp:idp-consent-api:4.2.1',
+    'net.shibboleth.idp:idp-profile-api:4.2.1',
+    'net.shibboleth.idp:idp-ui:4.2.1',
     'net.shibboleth.utilities:java-support:8.3.1',
-    'org.opensaml:opensaml-profile-api:4.2.0',
     'org.opensaml:opensaml-messaging-api:4.2.0',
+    'org.opensaml:opensaml-profile-api:4.2.0',
+    'org.opensaml:opensaml-storage-api:4.2.0',
   ].each {
     compile(it) {
       transitive = false
@@ -50,6 +52,7 @@ dependencies {
   compile 'commons-lang:commons-lang:2.6'
   compile 'org.apache.httpcomponents:httpcore:4.4.15'
   compile 'org.apache.httpcomponents:httpclient:4.5.13'
+  compile 'org.springframework:spring-core:5.3.19'
   compile 'com.googlecode.json-simple:json-simple:1.1.1'
   compile 'org.slf4j:slf4j-api:1.7.36'
 }

--- a/shibboleth-integration-idpv3/configuration/idpv3/addto-web.xml
+++ b/shibboleth-integration-idpv3/configuration/idpv3/addto-web.xml
@@ -41,7 +41,7 @@
       <servlet-class>aaf.vhr.idp.http.VhrRemoteUserAuthServlet</servlet-class>
       <init-param>
         <param-name>loginEndpoint</param-name>
-        <param-value><!-- https://VHR server address -->/login?ssourl=%s&amp;relyingparty=%s&amp;servicename=%s</param-value>
+        <param-value><!-- https://VHR server address -->/login?ssourl=%s&amp;relyingparty=%s&amp;servicename=%s&amp;mfa=%s</param-value>
       </init-param>
       <init-param>
         <param-name>apiServer</param-name>

--- a/shibboleth-integration-idpv3/configuration/idpv3/addto-web.xml
+++ b/shibboleth-integration-idpv3/configuration/idpv3/addto-web.xml
@@ -67,6 +67,10 @@
         <param-name>consentRevocationParamName</param-name>
         <param-value>_shib_idp_revokeConsent</param-value>
       </init-param>
+      <init-param>
+        <param-name>mfaPrincipalName</param-name>
+        <param-value>https://refeds.org/profile/mfa</param-value>
+      </init-param>
       <load-on-startup>4</load-on-startup>
     </servlet>
     <servlet-mapping>

--- a/shibboleth-integration-idpv3/configuration/idpv3/change-in-authn-general-authn.xml
+++ b/shibboleth-integration-idpv3/configuration/idpv3/change-in-authn-general-authn.xml
@@ -1,5 +1,13 @@
 
 <!-- declare support for forcedAuthentication -->
+<!-- set supportedPrincipals property (add nested bean) -->
         <bean id="authn/RemoteUser" parent="shibboleth.AuthenticationFlow"
             p:forcedAuthenticationSupported="true"
-            p:nonBrowserSupported="false" />
+            p:nonBrowserSupported="false" >
+
+            <property name="supportedPrincipalsByString">
+                <bean parent="shibboleth.CommaDelimStringArray"
+                    c:_0="#{'%{idp.authn.RemoteUser.supportedPrincipals:}'.trim()}" />
+            </property>
+
+        </bean>

--- a/shibboleth-integration-idpv3/configuration/idpv3/change-in-authn-general-authn.xml
+++ b/shibboleth-integration-idpv3/configuration/idpv3/change-in-authn-general-authn.xml
@@ -1,3 +1,5 @@
+
+<!-- declare support for forcedAuthentication -->
         <bean id="authn/RemoteUser" parent="shibboleth.AuthenticationFlow"
             p:forcedAuthenticationSupported="true"
             p:nonBrowserSupported="false" />

--- a/shibboleth-integration-idpv3/configuration/idpv3/change-in-authn-remoteuser--authn-config.xml
+++ b/shibboleth-integration-idpv3/configuration/idpv3/change-in-authn-remoteuser--authn-config.xml
@@ -1,0 +1,3 @@
+<!-- do not automatically add all principals supported by the flow -->
+
+     <util:constant id="shibboleth.authn.RemoteUser.addDefaultPrincipals" static-field="java.lang.Boolean.FALSE" />

--- a/shibboleth-integration-idpv3/src/aaf/vhr/idp/VhrSessionValidator.java
+++ b/shibboleth-integration-idpv3/src/aaf/vhr/idp/VhrSessionValidator.java
@@ -50,10 +50,10 @@ public class VhrSessionValidator {
 	}
 	
 	public String validateSession(String vhrSessionID) {
-		return validateSession(vhrSessionID, null, null, null);
+		return validateSession(vhrSessionID, null, false, null, null);
 	}
 
-	public String validateSession(String vhrSessionID, Instant notBefore, Instant authnInstantArr[], boolean mfaArr[]) {
+	public String validateSession(String vhrSessionID, Instant notBefore, boolean mfaRequested, Instant authnInstantArr[], boolean mfaArr[]) {
 		HttpClient httpClient = null;
 		HttpGet request = null;
 		HttpResponse response = null;
@@ -106,6 +106,12 @@ public class VhrSessionValidator {
 					};
 
 					Boolean mfa_obj = (Boolean) responseJSON.get("mfa");
+
+					// if MFA was requested and we are either missing mfa status or it is False, reject the session
+					if (mfaRequested && (mfa_obj == null || !mfa_obj.booleanValue())) {
+					    log.info("Rejecting username {} as MFA is requested but {}", remoteUser, mfa_obj==null ? "status is unknown" : "was not used");
+					    remoteUser = null;
+					};
 					
 					if(remoteUser != null) {
 						log.info("VHR API advises sessionID {} belongs to user {}, setting for REMOTE_USER.", vhrSessionID, remoteUser);

--- a/shibboleth-integration-idpv3/src/aaf/vhr/idp/VhrSessionValidator.java
+++ b/shibboleth-integration-idpv3/src/aaf/vhr/idp/VhrSessionValidator.java
@@ -50,10 +50,10 @@ public class VhrSessionValidator {
 	}
 	
 	public String validateSession(String vhrSessionID) {
-		return validateSession(vhrSessionID, null, null);
+		return validateSession(vhrSessionID, null, null, null);
 	}
 
-	public String validateSession(String vhrSessionID, Instant notBefore, Instant authnInstantArr[]) {
+	public String validateSession(String vhrSessionID, Instant notBefore, Instant authnInstantArr[], boolean mfaArr[]) {
 		HttpClient httpClient = null;
 		HttpGet request = null;
 		HttpResponse response = null;
@@ -104,12 +104,18 @@ public class VhrSessionValidator {
 					    log.info("Rejecting username {} as authnInstant {} is earlier than the notBefore threshold {}", remoteUser, authnInstant, notBefore);
 					    remoteUser = null;
 					};
+
+					Boolean mfa_obj = (Boolean) responseJSON.get("mfa");
 					
 					if(remoteUser != null) {
 						log.info("VHR API advises sessionID {} belongs to user {}, setting for REMOTE_USER.", vhrSessionID, remoteUser);
 						if (authnInstant != null && authnInstantArr != null && authnInstantArr.length>=1) {
 							log.info("VHR API sets authnInstant to {}.", authnInstant);
 							authnInstantArr[0]=authnInstant;
+						};
+						if (mfa_obj != null && mfaArr != null && mfaArr.length>=1) {
+							log.info("VHR API sets MFA status to {}.", mfa_obj.booleanValue());
+							mfaArr[0]= mfa_obj.booleanValue();
 						};
 						return remoteUser;
 					}

--- a/shibboleth-integration-idpv3/src/aaf/vhr/idp/http/VhrRemoteUserAuthServlet.java
+++ b/shibboleth-integration-idpv3/src/aaf/vhr/idp/http/VhrRemoteUserAuthServlet.java
@@ -214,11 +214,13 @@ public class VhrRemoteUserAuthServlet extends HttpServlet {
                         getSubcontext(RequestedPrincipalContext.class, false);
                 boolean mfaRequested = false;
 
-                if (rqPCtx != null && mfaPrincipalName != null) for (final Principal p: rqPCtx.getRequestedPrincipals()) {
-                    if (p.getName().equals(mfaPrincipalName)) {
-                        mfaRequested = true;
-                        log.debug("MFA Principal {} requested, signalling to application.", p.getName());
-                    }
+                if (rqPCtx != null && mfaPrincipalName != null) {
+                    for (final Principal p: rqPCtx.getRequestedPrincipals()) {
+                        if (p.getName().equals(mfaPrincipalName)) {
+                            mfaRequested = true;
+                            log.debug("MFA Principal {} requested, signalling to application.", p.getName());
+                        }
+                    };
                 };
 
                 // save session *key*
@@ -268,7 +270,7 @@ public class VhrRemoteUserAuthServlet extends HttpServlet {
 
             // If mfaPrincipalName is configured, add the correct set of principals to Subject.
             // The principal name matching MFA will only be added if MFA was used.
-            // Other principal names supported by this flow are ssumed to be SFA and will be added regardless of MFA.
+            // Other principal names supported by this flow are assumed to be SFA and will be added regardless of MFA.
             if (mfaPrincipalName != null) {
                 final AuthenticationFlowDescriptor authnFlow = getAuthenticationFlowDescriptor(key, httpRequest);
                 boolean mfaPrincipalFound = false;

--- a/shibboleth-integration-idpv3/src/aaf/vhr/idp/http/VhrRemoteUserAuthServlet.java
+++ b/shibboleth-integration-idpv3/src/aaf/vhr/idp/http/VhrRemoteUserAuthServlet.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.time.Instant;
 
 import javax.annotation.Nonnull;
+import javax.security.auth.Subject;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.Cookie;
@@ -30,6 +31,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 import net.shibboleth.idp.authn.context.AuthenticationContext;
+import net.shibboleth.idp.authn.principal.UsernamePrincipal;
 import net.shibboleth.idp.authn.ExternalAuthentication;
 import net.shibboleth.idp.authn.ExternalAuthenticationException;
 import net.shibboleth.idp.consent.context.ConsentManagementContext;
@@ -238,7 +240,11 @@ public class VhrRemoteUserAuthServlet extends HttpServlet {
                 httpRequest.setAttribute(ExternalAuthentication.AUTHENTICATION_INSTANT_KEY, authnInstantArr[0]);
             };
 
-            httpRequest.setAttribute(ExternalAuthentication.PRINCIPAL_NAME_KEY, username);
+            final Subject subject = new Subject();
+            subject.getPrincipals().add(new UsernamePrincipal(username));
+
+            // return subject with at UsernamePrincipal
+            httpRequest.setAttribute(ExternalAuthentication.SUBJECT_KEY, subject);
 
             ExternalAuthentication.finishExternalAuthentication(key, httpRequest, httpResponse);
 

--- a/shibboleth-integration-idpv3/src/aaf/vhr/idp/http/VhrRemoteUserAuthServlet.java
+++ b/shibboleth-integration-idpv3/src/aaf/vhr/idp/http/VhrRemoteUserAuthServlet.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.time.Instant;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.security.auth.Subject;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
@@ -32,10 +33,12 @@ import javax.servlet.http.HttpSession;
 
 import net.shibboleth.idp.authn.context.AuthenticationContext;
 import net.shibboleth.idp.authn.principal.UsernamePrincipal;
+import net.shibboleth.idp.authn.AuthenticationFlowDescriptor;
 import net.shibboleth.idp.authn.ExternalAuthentication;
 import net.shibboleth.idp.authn.ExternalAuthenticationException;
 import net.shibboleth.idp.consent.context.ConsentManagementContext;
 import net.shibboleth.idp.ui.context.RelyingPartyUIContext;
+import net.shibboleth.utilities.java.support.annotation.constraint.NotEmpty;
 
 import org.opensaml.profile.context.ProfileRequestContext;
 import org.apache.commons.codec.EncoderException;
@@ -258,5 +261,25 @@ public class VhrRemoteUserAuthServlet extends HttpServlet {
         }
     }
 // Checkstyle: CyclomaticComplexity|MethodLength ON
+
+    /**
+     * Get the executing {@link AuthenticationFlowDescriptor}.
+     *
+     * Reused from RemoteUserAuthServlet.
+     *
+     * @param key external authentication key
+     * @param httpRequest servlet request
+     *
+     * @return active descriptor, or null
+     * @throws ExternalAuthenticationException  if unable to access the profile context
+     */
+    @Nullable public AuthenticationFlowDescriptor getAuthenticationFlowDescriptor(@Nonnull @NotEmpty final String key,
+            @Nonnull final HttpServletRequest httpRequest) throws ExternalAuthenticationException {
+
+        final ProfileRequestContext prc =
+                ExternalAuthentication.getProfileRequestContext(key, httpRequest);
+        final AuthenticationContext authnCtx = prc.getSubcontext(AuthenticationContext.class);
+        return (authnCtx != null) ? authnCtx.getAttemptedFlow() : null;
+    }
 
 }

--- a/shibboleth-integration-idpv3/src/aaf/vhr/idp/http/VhrRemoteUserAuthServlet.java
+++ b/shibboleth-integration-idpv3/src/aaf/vhr/idp/http/VhrRemoteUserAuthServlet.java
@@ -69,6 +69,9 @@ public class VhrRemoteUserAuthServlet extends HttpServlet {
     /** Name of the request parameter that would indicate the user wants to revoke consent */
     private String consentRevocationParamName = "_shib_idp_revokeConsent";
 
+    /** Principal name to add to Subject only when MFA is used. */
+    private String mfaPrincipalName;
+
 // Checkstyle: CyclomaticComplexity OFF
     /** {@inheritDoc} */
     @Override
@@ -86,6 +89,8 @@ public class VhrRemoteUserAuthServlet extends HttpServlet {
         // Consent revocation parameter name: override default if set
         String crpn = config.getInitParameter("consentRevocationParamName");
         if (crpn != null) { consentRevocationParamName = crpn; };
+
+        mfaPrincipalName = config.getInitParameter("mfaPrincipalName");
 
         vhrSessionValidator = new VhrSessionValidator(apiServer, apiEndpoint, apiToken, apiSecret, requestingHost);
 

--- a/shibboleth-integration-idpv3/src/aaf/vhr/idp/http/VhrRemoteUserAuthServlet.java
+++ b/shibboleth-integration-idpv3/src/aaf/vhr/idp/http/VhrRemoteUserAuthServlet.java
@@ -101,8 +101,9 @@ public class VhrRemoteUserAuthServlet extends HttpServlet {
             boolean isVhrReturn = false;
             boolean isForceAuthn = false;
             Instant authnStart = null; // when this authentication started at the IdP
-            // array to use as return parameter when calling VhrSessionValidator
+            // arrays to use as return parameter when calling VhrSessionValidator
             Instant authnInstantArr[] = new Instant[1];
+            boolean mfaArr[] = new boolean[1];
 
             if (httpRequest.getParameter(REDIRECT_REQ_PARAM_NAME) != null) {
                 // we have come back from the VHR
@@ -169,7 +170,7 @@ public class VhrRemoteUserAuthServlet extends HttpServlet {
 
             if (vhrSessionID != null) {
                 log.info("Found vhrSessionID from {}. Establishing validity.", httpRequest.getRemoteHost());
-                username = vhrSessionValidator.validateSession(vhrSessionID, ( isForceAuthn ? authnStart : null), authnInstantArr);
+                username = vhrSessionValidator.validateSession(vhrSessionID, ( isForceAuthn ? authnStart : null), authnInstantArr, mfaArr);
             };
 
             // If we do not have a username yet (no Vhr session cookie or did not validate),

--- a/virtualhome/grails-app/controllers/aaf/vhr/LoginController.groovy
+++ b/virtualhome/grails-app/controllers/aaf/vhr/LoginController.groovy
@@ -128,7 +128,7 @@ class LoginController implements InitializingBean {
       return
     }
 
-    // if the account dnoes not have MFA yet but application requests it, redirect to MFA setup
+    // if the account does not have MFA yet but application requests it, redirect to MFA setup
     if(session.getAttribute(MFA_REQUESTED)?.equals(Boolean.TRUE) && !managedSubjectInstance.isUsingTwoStepLogin()){
       // This account needs to be updated before they can login
       log.info("Due to request from target service, the account $managedSubjectInstance must enroll into 2-Step verification before continuing login.")

--- a/virtualhome/grails-app/controllers/aaf/vhr/api/v1/LoginApiController.groovy
+++ b/virtualhome/grails-app/controllers/aaf/vhr/api/v1/LoginApiController.groovy
@@ -38,7 +38,7 @@ class LoginApiController extends aaf.base.api.ApiBaseController {
 
     if(remoteUserTuple) {
       log.info "API session verification for ${params.sessionID} provided response with remote_user of $remoteUserTuple.username"
-      render(contentType: 'application/json') { ['remote_user':remoteUserTuple.username, 'authnInstant':sdf.format(remoteUserTuple.authnInstant)] }
+      render(contentType: 'application/json') { ['remote_user':remoteUserTuple.username, 'authnInstant':sdf.format(remoteUserTuple.authnInstant), 'mfa':remoteUserTuple.mfa] }
     } else {
       log.error "API session verification for ${params.sessionID} failed, providing error response"
       response.status = 410

--- a/virtualhome/grails-app/services/aaf/vhr/LoginService.groovy
+++ b/virtualhome/grails-app/services/aaf/vhr/LoginService.groovy
@@ -152,7 +152,7 @@ class LoginService implements InitializingBean{
 
   public String establishSession(ManagedSubject managedSubjectInstance) {
     def sessionID = aaf.vhr.crypto.CryptoUtil.randomAlphanumeric(64)
-    def authnTuple = new AuthnTuple(managedSubjectInstance.login, new Date())
+    def authnTuple = new AuthnTuple(managedSubjectInstance.login, new Date(), managedSubjectInstance.isUsingTwoStepLogin())
     loginCache.put(sessionID, authnTuple)
 
     sessionID

--- a/virtualhome/grails-app/views/login/setuptwostep.gsp
+++ b/virtualhome/grails-app/views/login/setuptwostep.gsp
@@ -14,7 +14,13 @@
 
     <div class="row">
       <div class="span12">
-        <p>The Virtual Home now supports 2-Step verification, which is a secondary security measure used when logging into your account. The <strong>administrators of your account</strong> have enabled this for you, so simply follow the 3 steps below to set up and enable 2-Step verification to continue accessing Tuakiri services.</p>
+        <p>The Virtual Home now supports 2-Step verification, which is a secondary security measure used when logging into your account.
+        <g:if test="${managedSubjectInstance.enforceTwoStepLogin()}">
+        The <strong>administrators of your account</strong> have enabled this for you, so simply follow the 3 steps below to set up and enable 2-Step verification to continue accessing Tuakiri services.</p>
+        </g:if>
+        <g:else>
+        The service you are logging into requests stronger login security, so simply follow the 3 steps below to set up and enable 2-Step verification to continue accessing Tuakiri services.</p>
+        </g:else>
 
         <g:render template="/templates/appdetails" />
 

--- a/virtualhome/src/groovy/aaf/vhr/AuthnTuple.groovy
+++ b/virtualhome/src/groovy/aaf/vhr/AuthnTuple.groovy
@@ -5,10 +5,12 @@ import java.util.Date
 class AuthnTuple {
     String username
     Date authnInstant
+    boolean mfa
 
-    AuthnTuple(String _username, Date _authnInstant) {
+    AuthnTuple(String _username, Date _authnInstant, boolean _mfa ) {
         username = _username
         authnInstant = _authnInstant
+        mfa = _mfa
     }
 
 }

--- a/virtualhome/test/unit/aaf/vhr/LoginServiceSpec.groovy
+++ b/virtualhome/test/unit/aaf/vhr/LoginServiceSpec.groovy
@@ -39,7 +39,7 @@ class LoginServiceSpec extends spock.lang.Specification {
 
   def 'ensure content is stored in loginCache'() {
     when:
-    service.loginCache.put('abcd1234', new AuthnTuple('testuser', new Date()))
+    service.loginCache.put('abcd1234', new AuthnTuple('testuser', new Date(), false))
 
     then:
     service.loginCache.getIfPresent('abcd1234')?.username == 'testuser'
@@ -47,7 +47,7 @@ class LoginServiceSpec extends spock.lang.Specification {
 
   def 'get stored remote_user value'() {
     when:
-    service.loginCache.put('abcd1234', new AuthnTuple(remote_user, new Date()))
+    service.loginCache.put('abcd1234', new AuthnTuple(remote_user, new Date(), false))
 
     then:
     service.sessionRemoteUser(session)?.username == expected_remote_user

--- a/virtualhome/test/unit/aaf/vhr/api/v1/LoginApiControllerSpec.groovy
+++ b/virtualhome/test/unit/aaf/vhr/api/v1/LoginApiControllerSpec.groovy
@@ -49,10 +49,10 @@ class LoginApiControllerSpec extends spock.lang.Specification {
     controller.confirmsession()
 
     then:
-    1 * loginService.sessionRemoteUser(params.sessionID) >> new AuthnTuple('testuser', authnInstant)
+    1 * loginService.sessionRemoteUser(params.sessionID) >> new AuthnTuple('testuser', authnInstant, false)
     response.status == 200
     response.contentType == 'application/json;charset=UTF-8'
-    response.text == '{"remote_user":"testuser","authnInstant":"'+sdf.format(authnInstant)+'"}'
+    response.text == '{"remote_user":"testuser","authnInstant":"'+sdf.format(authnInstant)+'","mfa":false}'
   }
 
   def "basicauth: receive 410 is there is no such object"() {


### PR DESCRIPTION
Hi,

I see increasing demand for MFA in the Federated Identity Management space.

While the VHO already supports MFA, it is so far not able to signal whether MFA was used to the target service being accessed.

REFEDS has come up with a profile to be used for such signalling: https://refeds.org/profile/mfa
This value is to be used in outgoing SSO requests and in SSO responses as
`<saml2:AuthnContextClassRef>https://refeds.org/profile/mfa</saml2:AuthnContextClassRef>`

This PR adds support for the VHO to respond to such requests by:
(1) Making the VHO app expose to the IdP integration module whether the account is configured for MFA (all accounts configured with MFA use it automatically).
(2) Making the IdP integration module return the REFEDS MFA profile ID only if MFA is actually used.
(3) To support accounts that are not enrolled in MFA yet, pass the MFA request information to the VHO application's login  page, so that it can offer to the user to enroll in MFA to succeed in the authentication flow.

Some of the changes may look confusing, but little insight into the technical details of how the IdP works:
(i) each "authentication flow" is configured with authentication profile IDs it supports ("supportedPrincipals" setting)
(ii) by default, all these IDs get added to the authentication result as "fulfilled" (if "addDefaultPrincipals" setting is true, which is its defaults)
(iii) and the IdP then chooses which of these to return back to the service as actually used.  If the service requested a specific profile and it is in the result set, it is used.  If requested but not present, the authentication fails.    If not requested, one is chosen by the IdP.

To make this work for the REFEDS MFA, we have to add it to supportedPrincipals, but must also disable addDefaultPrincipals - otherwise it would be considered as fulfilled regardless of whether MFA is used.

So that's what the code in ee5f5e5 does: it considers the profile matching the configured ID (REFEDS MFA) as "protected" and adds this one only if MFA is used, while the others are all added automatically (mimicking what would otherwise happen with addDefaultPrincipals being true).

In review, I'm not asking for a detailed review of the Java and Groovy/Grails code, but rather for the logic outlined above (and, if one has the patience for it, whether the logic is correctly implemented).

Cheers,
Vlad
