### PR TITLE
new: ManagedSubject.login: restrict username to regexp

### DIFF
--- a/virtualhome/grails-app/controllers/aaf/vhr/FinalizationController.groovy
+++ b/virtualhome/grails-app/controllers/aaf/vhr/FinalizationController.groovy
@@ -30,7 +30,7 @@ class FinalizationController {
   }
 
   def loginAvailable(String login) {
-    if(login.contains(' ')) {
+    if(!login.matches('\\A[_a-zA-Z][-._a-zA-Z0-9]*\\z')) {
       render "false"
       return
     }

--- a/virtualhome/grails-app/domain/aaf/vhr/ManagedSubject.groovy
+++ b/virtualhome/grails-app/domain/aaf/vhr/ManagedSubject.groovy
@@ -85,7 +85,7 @@ class ManagedSubject {
                       group:Group]
 
   static constraints = {
-    login nullable:true, blank: false, unique: true, size: 5..100,  matches: '\\A[_a-zA-Z][-._a-zA-Z0-9]*\\z'
+    login nullable:true, blank: false, unique: true, size: 3..100,  matches: '\\A[_a-zA-Z][-._a-zA-Z0-9]*\\z'
     hash nullable:true, blank:false, minSize:60, maxSize:60
     totpKey nullable:true
 

--- a/virtualhome/grails-app/domain/aaf/vhr/ManagedSubject.groovy
+++ b/virtualhome/grails-app/domain/aaf/vhr/ManagedSubject.groovy
@@ -85,7 +85,7 @@ class ManagedSubject {
                       group:Group]
 
   static constraints = {
-    login nullable:true, blank: false, unique: true, size: 3..100,  validator: { val -> if (val?.contains(' ')) return 'value.contains.space' }
+    login nullable:true, blank: false, unique: true, size: 5..100,  matches: '\\A[_a-zA-Z][-._a-zA-Z0-9]*\\z'
     hash nullable:true, blank:false, minSize:60, maxSize:60
     totpKey nullable:true
 

--- a/virtualhome/grails-app/views/finalization/index.gsp
+++ b/virtualhome/grails-app/views/finalization/index.gsp
@@ -29,11 +29,12 @@
             </div>
             <div class="span4">
               <span class="help-block">
-                <p>You can choose anything you like for your username so long as:
+                <p>You can choose your own username meeting the following criteria:
                   <ul>
-                    <li>It is memorable for you;</li>
-                    <li>It is between 3 and 255 characters in length; and</li>
-                    <li>Contains no whitespace.</li>
+                    <li>It is memorable for you.</li>
+                    <li>It is between 3 and 255 characters in length.</li>
+                    <li>It contains only letters (<code>A-Za-z</code>), numbers (<code>0-9</code>), or a hyphen (<code>-</code>), dot (<code>.</code>) or underscore (<code>_</code>).</li>
+                    <li>It starts with a letter (<code>A-Za-z</code>) or underscore (<code>_</code>).</li>
                   </ul>
                 </p>
                 <br><br>

--- a/virtualhome/grails-app/views/finalization/index.gsp
+++ b/virtualhome/grails-app/views/finalization/index.gsp
@@ -32,7 +32,7 @@
                 <p>You can choose your own username meeting the following criteria:
                   <ul>
                     <li>It is memorable for you.</li>
-                    <li>It is between 3 and 255 characters in length.</li>
+                    <li>It is between 3 and 100 characters in length.</li>
                     <li>It contains only letters (<code>A-Za-z</code>), numbers (<code>0-9</code>), or a hyphen (<code>-</code>), dot (<code>.</code>) or underscore (<code>_</code>).</li>
                     <li>It starts with a letter (<code>A-Za-z</code>) or underscore (<code>_</code>).</li>
                   </ul>

--- a/virtualhome/grails-app/views/templates/_passwordinput.gsp
+++ b/virtualhome/grails-app/views/templates/_passwordinput.gsp
@@ -86,6 +86,7 @@
       login: {
         required: true,
         minlength: 3,
+        maxlength: 100,
         matchesPattern:true,
         remote: { url:"login-available", async:true }
       },

--- a/virtualhome/grails-app/views/templates/_passwordinput.gsp
+++ b/virtualhome/grails-app/views/templates/_passwordinput.gsp
@@ -77,16 +77,16 @@
     }
   }, "");
 
-  jQuery.validator.addMethod("noSpace", function(value, element) { 
-    return value.indexOf(" ") < 0 && value != ""; 
-  }, "Spaces are not permitted.");
+  jQuery.validator.addMethod("matchesPattern", function(value, element) {
+    return value.match(/^[_a-zA-Z][-_.a-zA-Z0-9]*$/) && value != "";
+  }, "Not a permitted username.");
 
   $("#accountform").validate({
     rules: {
       login: {
         required: true,
         minlength: 3,
-        noSpace:true,
+        matchesPattern:true,
         remote: { url:"login-available", async:true }
       },
       plainPassword: {

--- a/virtualhome/grails-app/views/templates/_passwordinput.gsp
+++ b/virtualhome/grails-app/views/templates/_passwordinput.gsp
@@ -79,7 +79,7 @@
 
   jQuery.validator.addMethod("matchesPattern", function(value, element) {
     return value.match(/^[_a-zA-Z][-_.a-zA-Z0-9]*$/) && value != "";
-  }, "Not a permitted username.");
+  }, "Username is not valid.");
 
   $("#accountform").validate({
     rules: {


### PR DESCRIPTION
Username should not not contain '@', which breaks eduPersonPrincipalName. Other chacaters could be an issue as well.
Usernames that are only numeric cause issues in certain use cases.

So far, only spaces were banned.

Switch to a regexp that enforces syntax typically expected of usernames:

* start with letter or underscore
* only contain letters, numbers, hyphen, dot, or underscore.