### PR TITLE
Fix QR code rendering for two-step authentication

### DIFF
--- a/virtualhome/grails-app/conf/BuildConfig.groovy
+++ b/virtualhome/grails-app/conf/BuildConfig.groovy
@@ -36,6 +36,8 @@ grails.project.dependency.resolution = {
     compile "commons-collections:commons-collections:3.2.2"
     compile "commons-validator:commons-validator:1.7"
     compile "com.google.guava:guava:14.0"
+    compile "com.google.zxing:core:3.5.3"
+    compile "com.google.zxing:javase:3.5.3"
     compile "edu.vt.middleware:vt-dictionary:3.0"
     compile "edu.vt.middleware:vt-password:3.1.1"
     compile "org.apache.shiro:shiro-quartz:1.2.5"

--- a/virtualhome/grails-app/domain/aaf/vhr/ManagedSubject.groovy
+++ b/virtualhome/grails-app/domain/aaf/vhr/ManagedSubject.groovy
@@ -232,8 +232,7 @@ class ManagedSubject {
   public String getEncodedTwoStepIssuer() {
     def issuer = Holders.config.aaf.vhr.twosteplogin.issuer
     if ( issuer && !issuer.isEmpty() )
-      // Double encode as used as parameter within parameter
-      URLEncoder.encode(URLEncoder.encode(issuer).replace('+', '%20'), 'UTF-8')
+      URLEncoder.encode(issuer).replace('+', '%20')
     else
       null
   }

--- a/virtualhome/src/java/aaf/vhr/crypto/GoogleAuthenticator.java
+++ b/virtualhome/src/java/aaf/vhr/crypto/GoogleAuthenticator.java
@@ -8,7 +8,6 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
 import org.apache.commons.codec.binary.Base32;
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.net.URLCodec;
 import org.apache.commons.codec.EncoderException;
 

--- a/virtualhome/src/java/aaf/vhr/crypto/GoogleAuthenticator.java
+++ b/virtualhome/src/java/aaf/vhr/crypto/GoogleAuthenticator.java
@@ -75,14 +75,7 @@ public class GoogleAuthenticator {
    * @return the URL for the QR code to scan
    */
   public static String getQRBarcodeURL(String user, String host, String secret, String issuer) throws WriterException, IOException {
-    String formatWithIssuer = "otpauth://totp/%s:%s@%s?secret=%s&issuer=%s";
-    String formatWithoutIssuer = "otpauth://totp/%s@%s?secret=%s";
-    String totpURL;
-    if (issuer != null) {
-      totpURL = String.format(formatWithIssuer, issuer, user, host, secret, issuer);
-    } else {
-      totpURL = String.format(formatWithoutIssuer, user, host, secret);
-    }
+    String totpURL = getTotpURL(user, host, secret, issuer);
 
     // generate data: image URL with ZXing
     // select Medium error correction
@@ -96,6 +89,14 @@ public class GoogleAuthenticator {
     MatrixToImageWriter.writeToStream(bitMatrix, "png", buffer);
     // return a data URL with Base64-encoded PNG image
     return "data:image/png;base64," + Base64.getEncoder().encodeToString(buffer.toByteArray());
+  }
+
+  private static String getTotpURL(String user, String host, String secret, String issuer) {
+    if (issuer != null) {
+      return String.format("otpauth://totp/%s:%s@%s?secret=%s&issuer=%s", issuer, user, host, secret, issuer);
+    } else {
+      return String.format("otpauth://totp/%s@%s?secret=%s", user, host, secret);
+    }
   }
 
   /**

--- a/virtualhome/test/unit/aaf/vhr/ManagedSubjectSpec.groovy
+++ b/virtualhome/test/unit/aaf/vhr/ManagedSubjectSpec.groovy
@@ -1062,7 +1062,7 @@ class ManagedSubjectSpec extends spock.lang.Specification  {
     def s = ManagedSubject.build(failedLogins:0, active:true, hash:'z0tYfrdu6V8stLN/hIu+xK8Rd5dsSueYwJ88XRgL2U4Z0JFSVspxsGOPK222')
 
     expect:
-    s.encodedTwoStepIssuer == 'Example%2520Org'
+    s.encodedTwoStepIssuer == 'Example%20Org'
   }
 
   def 'specified issuer returned as uri encoded when special char present'() {
@@ -1071,7 +1071,7 @@ class ManagedSubjectSpec extends spock.lang.Specification  {
     def s = ManagedSubject.build(failedLogins:0, active:true, hash:'z0tYfrdu6V8stLN/hIu+xK8Rd5dsSueYwJ88XRgL2U4Z0JFSVspxsGOPK222')
 
     expect:
-    s.encodedTwoStepIssuer == 'Example%2520%2526%2520Example%2520Org'
+    s.encodedTwoStepIssuer == 'Example%20%26%20Example%20Org'
   }
 
 

--- a/virtualhome/test/unit/aaf/vhr/crypto/GoogleAuthenticatorTest.groovy
+++ b/virtualhome/test/unit/aaf/vhr/crypto/GoogleAuthenticatorTest.groovy
@@ -7,24 +7,24 @@ public class GoogleAuthenticatorTest extends grails.test.GrailsUnitTestCase {
 
   public void testGenerateSecret() {
     String secret = GoogleAuthenticator.generateSecretKey();
-    String qrURL = GoogleAuthenticator.getQRBarcodeURL('testuser', 'vhr.test.edu.au', secret, null)
+    String totpURL = GoogleAuthenticator.getTotpURL('testuser', 'vhr.test.edu.au', secret, null)
 
     println secret
-    println qrURL
+    println totpURL
 
     assert secret.length() == 16
-    assert qrURL == "https://chart.googleapis.com/chart?chs=200x200&chld=M%7C0&cht=qr&chl=otpauth://totp/testuser@vhr.test.edu.au%3Fsecret%3D" + secret
+    assert totpURL == "otpauth://totp/testuser@vhr.test.edu.au?secret=" + secret
   }
 
   public void testGenerateSecretWithIssuer() {
     String secret = GoogleAuthenticator.generateSecretKey();
-    String qrURL = GoogleAuthenticator.getQRBarcodeURL('testuser', 'vhr.test.edu.au', secret, "Issuer%2520Org")
+    String totpURL = GoogleAuthenticator.getTotpURL('testuser', 'vhr.test.edu.au', secret, "Issuer%20Org")
 
     println secret
-    println qrURL
+    println totpURL
 
     assert secret.length() == 16
-    assert qrURL == "https://chart.googleapis.com/chart?chs=200x200&chld=M%7C0&cht=qr&chl=otpauth://totp/Issuer%2520Org:testuser@vhr.test.edu.au%3Fsecret%3D" + secret + "%26issuer%3DIssuer%2520Org"
+    assert totpURL == "otpauth://totp/Issuer%20Org:testuser@vhr.test.edu.au?secret=" + secret + "&issuer=Issuer%20Org"
   }
 
   /*


### PR DESCRIPTION
Google has shut down the Google Charts API that the VHO was using to render the QR codes.

Use ZXing (https://github.com/zxing/zxing), a Google project made open.

Generate a PNG image in-memory and export it via a data URL (base64 encoded).

This also improve security by not passing secrets through a 3rd party service.

As the totpURL is rendered directly, there is no need to encode query string special characters, so drop double-encoding in format strings and in `ManagedSubject.getEncodedTwoStepIssuer()`.

Fix tests.