### PR TITLE
Remove mention of incorrect username from password recovery.

### DIFF
--- a/virtualhome/grails-app/i18n/messages.properties
+++ b/virtualhome/grails-app/i18n/messages.properties
@@ -384,7 +384,7 @@ controllers.aaf.vhr.account.completedetailschange.success=Your details have been
 controllers.aaf.vhr.account.finish.twostep.error=Unable to validate your 2-Step verification code, please try again.
 controllers.aaf.vhr.account.finish.twostep.success=Successfully enabled 2-step verification for your account.
 
-controllers.aaf.vhr.lostpassword.requiresaccount=The account details provided could not be validated. Please ensure you have entered the correct username.
+controllers.aaf.vhr.lostpassword.requiresaccount=The account details provided could not be validated.
 controllers.aaf.vhr.lostpassword.emailcode.error=The email code you entered was incorrect.
 controllers.aaf.vhr.lostpassword.externalcode.error=The SMS or administrator provided code you entered was incorrect.
 controllers.aaf.vhr.lostpassword.validatereset.new.password.invalid=The password you provided was not valid.


### PR DESCRIPTION
Covers the item https://app.clickup.com/t/86cw9gya3 

There are three areas where you can enter a username before logging in, which are the areas of concern:

1. Using the _recover lost username_ option. This lets you enter an email. You will get the response **An email has been sent to the address you provided with information about your Tuakiri Virtual Home account.** regardless of whether the email exists or not. This means this is not a concern for us.
2. Using the _change your password_ option. This can only be done once you first log in, so is not a concern for us.
3. Using the _recover your lost password_ option. This is what has been changed. The old message is _The account details provided could not be validated. Please ensure you have entered the correct username._. The new message removes the mention of entering the correct username.