### PR TITLE
new: make all new groups default to two-step-auth required

### DIFF
--- a/virtualhome/grails-app/domain/aaf/vhr/Group.groovy
+++ b/virtualhome/grails-app/domain/aaf/vhr/Group.groovy
@@ -16,7 +16,7 @@ class Group {
 
   String welcomeMessage
 
-  boolean totpForce       // All accounts must setup 2-Step Verification and can't opt out
+  boolean totpForce = true       // All accounts must setup 2-Step Verification and can't opt out
 
   boolean active = true
   boolean blocked = false


### PR DESCRIPTION
Tested on tuakiri-vho-dev - creates new groups as requiring two step authentication.