### PR TITLE
bau: Remove blackberry and windows 8 phone from list of devices

### DIFF
--- a/virtualhome/grails-app/views/templates/_appdetails.gsp
+++ b/virtualhome/grails-app/views/templates/_appdetails.gsp
@@ -13,7 +13,7 @@
     <h5>Step 1: Using your device, download the authenticator application (app) from an app store </h5>
     <p>Download instructions for each app store is below. If you have already downloaded the app, proceed to step 2. </p>
     <ul>
-      <li><strong>iPhone</strong> search the <a href="http://itunes.apple.com/us/app/google-authenticator/id388497605?mt=8">Apple App Store</a> for “Google Authenticator” (published by Google, Inc.)</li>
+      <li><strong>iPhone</strong> search the <a href="https://apps.apple.com/us/app/google-authenticator/id388497605">Apple App Store</a> for “Google Authenticator” (published by Google, Inc.)</li>
       <li><strong>Android</strong> search the <a href="https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2">Google Play Store</a> for “Google Authenticator” (published by Google, Inc.)  </li>
     </ul>
   </li>

--- a/virtualhome/grails-app/views/templates/_appdetails.gsp
+++ b/virtualhome/grails-app/views/templates/_appdetails.gsp
@@ -15,8 +15,6 @@
     <ul>
       <li><strong>iPhone</strong> search the <a href="http://itunes.apple.com/us/app/google-authenticator/id388497605?mt=8">Apple App Store</a> for “Google Authenticator” (published by Google, Inc.)</li>
       <li><strong>Android</strong> search the <a href="https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2">Google Play Store</a> for “Google Authenticator” (published by Google, Inc.)  </li>
-      <li><strong>Blackberry</strong> search the <a href="http://appworld.blackberry.com/webstore/content/22517879/?lang=en&countrycode=AU">Blackberry World</a> for “Authomator” (published by Pulsecode Inc.) </li>
-      <li><strong>Windows Phone 8</strong> search the <a href="http://www.windowsphone.com/en-us/store/app/authenticator/e7994dbc-2336-4950-91ba-ca22d653759b">Windows Phone Store</a> for “Authenticator” (published by Microsoft Corporation) </li>
     </ul>
   </li>
 


### PR DESCRIPTION
I think there's more good to removing these phones from the list than having them. Keeping them makes it look like we don't ever update our software, and I think it's highly unlikely that anyone using the virtual home software would still be using a blackberry or windows phone.