### PR TITLE
fix: MyAcct/Finalize: do not remove session attr if not complete

### DIFF
--- a/virtualhome/grails-app/controllers/aaf/vhr/FinalizationController.groovy
+++ b/virtualhome/grails-app/controllers/aaf/vhr/FinalizationController.groovy
@@ -61,13 +61,14 @@ class FinalizationController {
       return
     }
 
-    session.removeAttribute(MANAGED_SUBJECT_ID)
-
     def (outcome, managedSubjectInstance) = managedSubjectService.finalize(invitationInstance, login, plainPassword, plainPasswordConfirmation, mobileNumber ?:null)
     if(!outcome) {
       render (view: 'index', model:[managedSubjectInstance:managedSubjectInstance, invitationInstance:invitationInstance])
       return
     }
+
+    session.removeAttribute(MANAGED_SUBJECT_ID)
+
     [managedSubjectInstance: managedSubjectInstance]
   }
 


### PR DESCRIPTION
Do not remove the MANAGED_SUBJECT_ID session attribute if the finalization flow is not complete.

(follow-up to #6)