### PR TITLE
Fix the password reset logic and error handling

### DIFF
--- a/virtualhome/grails-app/controllers/aaf/vhr/LostPasswordController.groovy
+++ b/virtualhome/grails-app/controllers/aaf/vhr/LostPasswordController.groovy
@@ -9,7 +9,7 @@ import aaf.vhr.switchch.vho.DeprecatedSubject
 
 class LostPasswordController {
 
-  static allowedMethods = [emailed: 'POST', validatereset: 'POST']
+  static allowedMethods = [emailed: 'POST', validatereset: 'POST', obtainsubject: 'GET']
 
   final String CURRENT_USER = "aaf.vhr.LostPasswordController.CURRENT_USER"
   final String EMAIL_CODE_SUBJECT ='controllers.aaf.vhr.lostpassword.email.code.subject'

--- a/virtualhome/grails-app/controllers/aaf/vhr/LostPasswordController.groovy
+++ b/virtualhome/grails-app/controllers/aaf/vhr/LostPasswordController.groovy
@@ -42,6 +42,11 @@ class LostPasswordController {
 
     def managedSubjectInstance = ManagedSubject.findWhere(login: params.login)
     if (managedSubjectInstance) {
+
+      def smsCode = aaf.vhr.crypto.CryptoUtil.randomAlphanumeric(grailsApplication.config.aaf.vhr.passwordreset.reset_code_length)
+      managedSubjectInstance.resetCodeExternal = smsCode
+      managedSubjectInstance.save()
+
       lostPasswordService.sendResetEmail(managedSubjectInstance)
     }
 
@@ -69,9 +74,6 @@ class LostPasswordController {
 
     session.setAttribute(CURRENT_USER, managedSubjectInstance.id)
 
-    // If we haven't generated an SMS code already, generate an SMS code and sent it to the user (even if we have already sent one)
-    def smsCode = aaf.vhr.crypto.CryptoUtil.randomAlphanumeric(grailsApplication.config.aaf.vhr.passwordreset.reset_code_length)
-    managedSubjectInstance.resetCodeExternal = smsCode
     flash.type = 'info'
     flash.message = 'controllers.aaf.vhr.lostpassword.reset.sent.externalcode'
     sendResetCodes(managedSubjectInstance)

--- a/virtualhome/grails-app/controllers/aaf/vhr/LostPasswordController.groovy
+++ b/virtualhome/grails-app/controllers/aaf/vhr/LostPasswordController.groovy
@@ -105,7 +105,12 @@ class LostPasswordController {
         flash.type = 'error'
         flash.message = 'controllers.aaf.vhr.lostpassword.resend.error'
       } else {
-        sendResetCodes(managedSubjectInstance)
+        if (!sendResetCodes(managedSubjectInstance)) {
+          flash.type = 'error'
+          flash.message = 'controllers.aaf.vhr.lostpassword.mobile.invalid'
+          redirect action: 'unavailable'
+          return
+        }
 
         managedSubjectInstance.lastCodeResend = new Date()
         managedSubjectInstance.save()

--- a/virtualhome/grails-app/domain/aaf/vhr/ManagedSubject.groovy
+++ b/virtualhome/grails-app/domain/aaf/vhr/ManagedSubject.groovy
@@ -517,6 +517,8 @@ class ManagedSubject {
 
     checkedNumber = checkedNumber.replace(' ','')
 
+    checkedNumber = checkedNumber.replace('-','')
+
     if(!checkedNumber.startsWith('+')) {
       return false
     } else {

--- a/virtualhome/grails-app/domain/aaf/vhr/ManagedSubject.groovy
+++ b/virtualhome/grails-app/domain/aaf/vhr/ManagedSubject.groovy
@@ -516,7 +516,7 @@ class ManagedSubject {
     }
 
     // Silently remove anything that might be entered by users in a valid-looking phone number.
-    checkedNumber = checkedNumber.replaceAll("[ .\\-()]", '')
+    checkedNumber = checkedNumber.replaceAll("[- .()]", '')
 
     // Valid phone numbers for the app only contain '+' and 0-9. Anything else is probably junk that users will be warned about.
     def newNumber = checkedNumber.replaceAll("[^0-9+]", '')

--- a/virtualhome/grails-app/domain/aaf/vhr/ManagedSubject.groovy
+++ b/virtualhome/grails-app/domain/aaf/vhr/ManagedSubject.groovy
@@ -515,15 +515,20 @@ class ManagedSubject {
       checkedNumber = "+64$checkedNumber"
     }
 
-    checkedNumber = checkedNumber.replace(' ','')
+    // Silently remove anything that might be entered by users in a valid-looking phone number.
+    checkedNumber = checkedNumber.replaceAll("[ .\\-()]", '')
 
-    checkedNumber = checkedNumber.replace('-','')
-
-    if(!checkedNumber.startsWith('+')) {
+    // Valid phone numbers for the app only contain '+' and 0-9. Anything else is probably junk that users will be warned about.
+    def newNumber = checkedNumber.replaceAll("[^0-9+]", '')
+    if (newNumber != checkedNumber) {
       return false
-    } else {
-      obj.mobileNumber = checkedNumber
-      return true
     }
+
+    if(!newNumber.startsWith('+')) {
+      return false
+    }
+
+    obj.mobileNumber = newNumber
+    return true
   }
 }

--- a/virtualhome/grails-app/i18n/messages.properties
+++ b/virtualhome/grails-app/i18n/messages.properties
@@ -400,7 +400,7 @@ controllers.aaf.vhr.lostpassword.reset.sent.externalcode=Your password reset cod
 controllers.aaf.vhr.lostpassword.reset.sent.email=Your password reset code has been sent via an email. Please allow at least 5 minutes for codes to be delivered.
 controllers.aaf.vhr.lostpassword.reset.mobile.missing=You must have a mobile number configured to receive an SMS code. Please contact your administrators for more information.
 controllers.aaf.vhr.lostpassword.reset.url.badsecret=An error has occurred while attempting to reset your password. Please try again.
-controllers.aaf.vhr.lostpassword.mobile.invalid=You cannot be sent a reset code because of an issue with your configured mobile number. Please contact an administrator to fix this.
+controllers.aaf.vhr.lostpassword.mobile.invalid=A reset code could not be sent to you because of an issue with your configured mobile number. Please contact one of our administrators to address this.
 
 controllers.aaf.vhr.lostusername.email.subject=Your Tuakiri Virtual Home username
 controllers.aaf.vhr.lostusername.recaptcha.error=Data supplied for the recaptcha field could not be verified

--- a/virtualhome/grails-app/i18n/messages.properties
+++ b/virtualhome/grails-app/i18n/messages.properties
@@ -400,6 +400,7 @@ controllers.aaf.vhr.lostpassword.reset.sent.externalcode=Your password reset cod
 controllers.aaf.vhr.lostpassword.reset.sent.email=Your password reset code has been sent via an email. Please allow at least 5 minutes for codes to be delivered.
 controllers.aaf.vhr.lostpassword.reset.mobile.missing=You must have a mobile number configured to receive an SMS code. Please contact your administrators for more information.
 controllers.aaf.vhr.lostpassword.reset.url.badsecret=An error has occurred while attempting to reset your password. Please try again.
+controllers.aaf.vhr.lostpassword.mobile.invalid=You cannot be sent a reset code because of an issue with your configured mobile number. Please contact an administrator to fix this.
 
 controllers.aaf.vhr.lostusername.email.subject=Your Tuakiri Virtual Home username
 controllers.aaf.vhr.lostusername.recaptcha.error=Data supplied for the recaptcha field could not be verified


### PR DESCRIPTION
These changes aim to fix the following issues that were found regarding password reset logic:

* Users navigating to the password reset page after receiving a reset code from an admin would cause said code to be replaced by a new one.
* Phone numbers with dashes were not being sanitized at any point before being used for attempted SMS's.
* Attempted error handling during SMS send failures would fail due to multiple redirect attempts.
* Sometimes users would receive multiple SMS messages during a single password reset attempt due to one being sent every time `obtainsubject` is hit.

These changes have been tested by myself on a dev instance. I believe they should fix these issues.