### PR TITLE
fix: improve Deactivated email template

### DIFF
--- a/virtualhome/src/groovy/aaf/vhr/deactivated_managed_subject.gsp
+++ b/virtualhome/src/groovy/aaf/vhr/deactivated_managed_subject.gsp
@@ -9,20 +9,17 @@ Your username for this account is: <em>${managedSubject.login.encodeAsHTML()}</e
 
 To have your account checked and re-enabled please contact one of the administrators shown below.<br><br>
 
-<h5>Primary Administrators</h5>
 <g:if test="${groupRole.subjects?.size() > 0}">
+<h5>Primary Administrators</h5>
   <ul>
     <g:each in="${groupRole.subjects?.sort{it.cn}}" var="subject">
       <li><g:fieldValue bean="${subject}" field="cn"/> - <a href="mailto:${subject.email}"><g:fieldValue bean="${subject}" field="email"/></a></li>
     </g:each>
   </ul>
-</g:if>
-<g:else>
-  Unfortunately there are no primary administrators available for your account.
-</g:else>
-<br><br>
+<br>
 
 <h5>Secondary Administrators</h5>
+</g:if>
 <g:if test="${organizationRole.subjects?.size() > 0}">
   <ul>
     <g:each in="${organizationRole.subjects?.sort{it.cn}}" var="subject">
@@ -31,7 +28,7 @@ To have your account checked and re-enabled please contact one of the administra
   </ul>
 </g:if>
 <g:else>
-  Unfortunately there are no secondary administrators available for your account.
+  Unfortunately there are no administrators available for your account.<br>
 </g:else>
 <br>
 


### PR DESCRIPTION
Avoid confusing part with "No primary administrators" message - which is rendered in most cases - as Primary (Group level) administrator is almost never specified.

If there are no group administrators, skip the Primary and Secondary administrators headeer and only render the list of (Organization-level) administrators, or display message saying no administrators are configured. (Skip the term "secondary", the then message reads well whether the headings are included or not).

Slightly adjust whitespace (reduce two linebreaks to one, add a linebreak after final message).